### PR TITLE
ci: use the HEAD commit during checkout

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:


### PR DESCRIPTION
### Describe the pull request

The checkout action makes a merge commit by default. This commit aims at preserving the HEAD commit. This fix is being proposed to make the DeepSource Test coverage analyzer work.
Link to the issue: n/a

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/flamego/flamego/blob/main/.github/contributing.md).
- [ ] I have added test cases to cover the new code.
